### PR TITLE
Update image.js - use variable instead of this keyword

### DIFF
--- a/src/core/image.js
+++ b/src/core/image.js
@@ -135,10 +135,10 @@ function getImageData(img) {
 				} else {
 					let http = new XMLHttpRequest();
 					http.onreadystatechange = function () {
-						if (this.readyState !== XHR_DONE) return;
+						if (http.readyState !== XHR_DONE) return;
 
-						if (this.status === 200 || this.status === 0) {
-							resolve(this.response);
+						if (http.status === 200 || http.status === 0) {
+							resolve(http.response);
 						} else {
 							reject('Warning: could not load an image to parse its orientation');
 						}


### PR DESCRIPTION
When using vue advanced cropper with libraries like offline.js, which overrides XHR request. tends to got `this` as `null`


we can use direct variable instead of this keyword