### PR TITLE
feat: expand types of `Cropper` component

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -149,7 +149,39 @@ export interface CropperResult {
 }
 
 export declare const Cropper: DefineComponent<
-	any,
+  {
+    src?: string;
+    backgroundClass?: string;
+    foregroundClass?: string;
+    imageRestriction?: 'fill-area' | 'fit-area' | 'stencil' | 'none';
+    defaultBoundaries?: 'fill';
+    defaultPosition?: Limits;
+    defaultVisibleArea?: Coordinates;
+    defaultSize?: Size | ((size: { visibleArea : VisibleArea , imageSize: ImageSize }) => Size);
+    stencilSize?: Size | ((size: { boundaries: Boundaries }) => Size);
+    stencilProps?: {
+      lines?: unknown;
+      handlers?: unknown;
+      movable?: boolean;
+      resizable?: boolean;
+      scalable?: boolean;
+      aspectRatio?: number;
+      previewClass?: string;
+      minAspectRatio?: number;
+      maxAspectRatio?: number;
+      handlerComponent?: unknown;
+      handlersClasses?: Record<string, string>;
+    };
+    stencilComponent?: string;
+    canvas?: boolean | SizeRestrictions;
+    debounce?: boolean;
+    transitions?: boolean;
+    minWidth?: number;
+    minHeight?: number;
+    priority?: 'visibleArea';
+    sizeRestrictionsAlgorithm?: 'pixelsRestriction';
+    defaultTransforms?: unknown;
+  },
 	{
 		getResult: () => CropperResult;
 		setCoordinates: (transform: Transform | Transform[]) => void;
@@ -159,7 +191,13 @@ export declare const Cropper: DefineComponent<
 		rotate: (angle: number) => void;
 		flip: (horizontal: boolean, vertical?: boolean) => void;
 		reset: () => void;
-	}
+	},
+  {imageSize: ImageSize, sizeRestrictions: SizeRestrictions; coordinates: Coordinates},
+  {},
+  {},
+  {},
+  {},
+  {ready: () => void; change: (event: CropperResult) => void; error: () => void;}
 >;
 
 export declare const PreviewResult: DefineComponent<any>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -149,39 +149,39 @@ export interface CropperResult {
 }
 
 export declare const Cropper: DefineComponent<
-  {
-    src?: string;
-    backgroundClass?: string;
-    foregroundClass?: string;
-    imageRestriction?: 'fill-area' | 'fit-area' | 'stencil' | 'none';
-    defaultBoundaries?: 'fill';
-    defaultPosition?: Limits;
-    defaultVisibleArea?: Coordinates;
-    defaultSize?: Size | ((size: { visibleArea : VisibleArea , imageSize: ImageSize }) => Size);
-    stencilSize?: Size | ((size: { boundaries: Boundaries }) => Size);
-    stencilProps?: {
-      lines?: unknown;
-      handlers?: unknown;
-      movable?: boolean;
-      resizable?: boolean;
-      scalable?: boolean;
-      aspectRatio?: number;
-      previewClass?: string;
-      minAspectRatio?: number;
-      maxAspectRatio?: number;
-      handlerComponent?: unknown;
-      handlersClasses?: Record<string, string>;
-    };
-    stencilComponent?: string;
-    canvas?: boolean | SizeRestrictions;
-    debounce?: boolean;
-    transitions?: boolean;
-    minWidth?: number;
-    minHeight?: number;
-    priority?: 'visibleArea';
-    sizeRestrictionsAlgorithm?: 'pixelsRestriction';
-    defaultTransforms?: unknown;
-  },
+	{
+		src?: string;
+		backgroundClass?: string;
+		foregroundClass?: string;
+		imageRestriction?: 'fill-area' | 'fit-area' | 'stencil' | 'none';
+		defaultBoundaries?: 'fill';
+		defaultPosition?: Limits;
+		defaultVisibleArea?: Coordinates;
+		defaultSize?: Size | ((size: { visibleArea : VisibleArea , imageSize: ImageSize }) => Size);
+		stencilSize?: Size | ((size: { boundaries: Boundaries }) => Size);
+		stencilProps?: {
+			lines?: unknown;
+			handlers?: unknown;
+			movable?: boolean;
+			resizable?: boolean;
+			scalable?: boolean;
+			aspectRatio?: number;
+			previewClass?: string;
+			minAspectRatio?: number;
+			maxAspectRatio?: number;
+			handlerComponent?: unknown;
+			handlersClasses?: Record<string, string>;
+		};
+		stencilComponent?: string;
+		canvas?: boolean | SizeRestrictions;
+		debounce?: boolean;
+		transitions?: boolean;
+		minWidth?: number;
+		minHeight?: number;
+		priority?: 'visibleArea';
+		sizeRestrictionsAlgorithm?: 'pixelsRestriction';
+		defaultTransforms?: unknown;
+	},
 	{
 		getResult: () => CropperResult;
 		setCoordinates: (transform: Transform | Transform[]) => void;
@@ -192,12 +192,20 @@ export declare const Cropper: DefineComponent<
 		flip: (horizontal: boolean, vertical?: boolean) => void;
 		reset: () => void;
 	},
-  {imageSize: ImageSize, sizeRestrictions: SizeRestrictions; coordinates: Coordinates},
-  {},
-  {},
-  {},
-  {},
-  {ready: () => void; change: (event: CropperResult) => void; error: () => void;}
+	{
+		imageSize: ImageSize;
+		sizeRestrictions: SizeRestrictions; 
+		coordinates: Coordinates;
+	},
+	{},
+	{},
+	{},
+	{},
+	{
+		ready: () => void;
+		change: (event: CropperResult) => void;
+		error: () => void;
+	}
 >;
 
 export declare const PreviewResult: DefineComponent<any>;


### PR DESCRIPTION
I have started using this library in a project (it's working great!) and noticed the types were lacking so I've done my best to fill them out as I've used them + based on the documentation.

I know they're not complete, but it should be easy to expand them further as people use the types